### PR TITLE
goals list css styles updated

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -92,16 +92,15 @@ body {
 
 /* Training Info Block start */
 .TrainingInfoBlock {
-  background-color: rgba(126, 121, 121, 0.25);
   border-radius: 5px;
   display: flex;
   align-items: center;
   justify-content: center;
   width: 45%;
-  margin: 25px 40% 12.5px 10%;
-  animation: slideIn 2.35s forwards;
-  -webkit-animation: slideIn 2.35s forwards;
-  -moz-animation: slideIn 2.35s forwards;
+  margin: 10px 40% 12.5px 10%;
+  animation: slideIn 1.5s forwards;
+  -webkit-animation: slideIn 1.5s forwards;
+  -moz-animation: slideIn 1.5s forwards;
 }
 
 .TrainingInfoBlock h2 {
@@ -117,16 +116,15 @@ body {
 
 /* Tracking Info Block start */
 .TrackingInfoBlock {
-  background-color: rgba(126, 121, 121, 0.25);
   border-radius: 5px;
   display: flex;
   align-items: center;
   justify-content: center;
   width: 45%;
   margin: 12.5px 20%;
-  animation: slideIn 2.75s forwards;
-  -webkit-animation: slideIn 2.75s forwards;
-  -moz-animation: slideIn 2.75s forwards;
+  animation: slideIn 1.5s forwards;
+  -webkit-animation: slideIn 1.5s forwards;
+  -moz-animation: slideIn 1.5s forwards;
 }
 
 .TrackingInfoBlock h2 {
@@ -143,16 +141,15 @@ body {
 
 /* Sharing Info Block start */
 .SharingInfoBlock {
-  background-color: rgba(126, 121, 121, 0.25);
   border-radius: 5px;
   display: flex;
   align-items: center;
   justify-content: center;
   width: 45%;
-  margin: 12.5px 10% 25px 40%;
-  animation: slideIn 3.25s forwards;
-  -webkit-animation: slideIn 3.25s forwards;
-  -moz-animation: slideIn 3.25s forwards;
+  margin: 12.5px 10% 10px 40%;
+  animation: slideIn 1.5s forwards;
+  -webkit-animation: slideIn 1.5s forwards;
+  -moz-animation: slideIn 1.5s forwards;
 }
 
 .SharingInfoBlock h2 {
@@ -291,7 +288,81 @@ body {
 
 /* End CSS for footer */
 
+/* Goals Page Specific CSS */
 
+.goals-list-add-goal-button {
+  padding: 5px 7px;
+  background-color: #022d64;
+  color: #FFF;
+  width: 100px;
+  margin: 15px;
+  cursor: pointer;
+  border: 2px solid #022d64;
+  border-radius: 5px;
+  transition-duration: 0.4s;
+}
+
+.goals-list-add-goal-button:hover,
+.set-goal-button:hover {
+  background-color: #F2EEE1;
+  color: #022d64;
+}
+
+.goals-list-text-area {
+  list-style: none;
+  border-top: none;
+  border-left: none;
+  border-right: none;
+  border-bottom:3px solid #022d64;
+  margin: 5px;
+  height: 40px;
+  background-color: #446DA3;
+  color: #f7f5f5;
+  font-size: 1.5rem;
+}
+
+.goals-list-text-area:focus{
+  border: none;
+}
+
+.goals-list-text-area::placeholder { 
+  color: #f7f5f5;
+  opacity: 1; /* Firefox */
+}
+
+.remove-goal-button {
+  justify-content: center;
+  padding: 5px 7px;
+  background-color: #022d64;
+  color: #FFF;
+  width: 25px;
+  margin: 10px;
+  cursor: pointer;
+  border: 2px solid #022d64;
+  border-radius: 5px;
+  transition-duration: 0.4s;
+}
+
+.remove-goal-button:hover {
+  background-color: #f55151;
+}
+
+.set-goal-button {
+  justify-content: center;
+  padding: 5px 7px;
+  background-color: #022d64;
+  color: #FFF;
+  width: 50px;
+  margin: 5px;
+  cursor: pointer;
+  border: 2px solid #022d64;
+  border-radius: 5px;
+  transition-duration: 0.4s;
+}
+
+
+
+/* End Goals Page Specific CSS */
 
 /* Media Queries */
 @media screen and (min-width: 768px) {

--- a/src/pages/GoalsPage.js
+++ b/src/pages/GoalsPage.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Formik, Form, Field, FieldArray } from 'formik';
 import GoalsPageSchema from '../utils/GoalsPageSchema';
+import { isNonEmptyArray } from '@apollo/client/utilities';
 // ErrorMessage can be used, need to look into it more to figure out how
 
 
@@ -30,7 +31,7 @@ const GoalsPage = () => (
                name="goals"
                render={(arrayHelpers) => (
                  <div>
-                   <button type="button" onClick={() => arrayHelpers.push("")}>
+                   <button className="goals-list-add-goal-button" type="button" onClick={() => arrayHelpers.push("")}>
                      {/* show this when user has removed all goals from the list */}
                      Add a Goal
                    </button>
@@ -40,22 +41,26 @@ const GoalsPage = () => (
                          <Field name={`goals.${index}`}>
                            {({ field, meta }) => (
                              <div style={{ display: 'flex'}}>
-                               <input type="text" {...field} placeholder="Goal"/>
+                               <input title="Goal, click to edit" className="goals-list-text-area" type="text" {...field} placeholder="Goal"/>
                                <button
+                                 title="Remove Goal"
+                                 className="remove-goal-button"
                                  type="button"
                                  onClick={() => arrayHelpers.remove(index)} // remove a friend from the list
                                >
                                  -
                                </button>
                                <button
+                                 className="set-goal-button"
                                  type="button"
                                  onClick={() => {
                                    arrayHelpers.replace(index, props.values.goals[index])
                                  }
                                  }
+                                
                                  // insert an empty string at a position
                                >
-                                 Edit
+                                 Set
                                </button>
                                {meta.touched &&
                                meta.error && <div className="error">{meta.error}</div>}

--- a/src/pages/GoalsPage.js
+++ b/src/pages/GoalsPage.js
@@ -41,7 +41,7 @@ const GoalsPage = () => (
                          <Field name={`goals.${index}`}>
                            {({ field, meta }) => (
                              <div style={{ display: 'flex'}}>
-                               <input title="Goal, click to edit" className="goals-list-text-area" type="text" {...field} placeholder="Goal"/>
+                               <input title="Goal, click to edit" className="goals-list-text-area" type="text" {...field} placeholder="Click to enter new goal."/>
                                <button
                                  title="Remove Goal"
                                  className="remove-goal-button"


### PR DESCRIPTION
Updated Goals Page CSS styles for goals list:

Initial style testing for goals page:

- Changed text color.
- Changed text area styling.
- Changed styling for when 'focused'.
- Changed styling for add goal button.
- Changed styling for remove goal button. 
- Added 'title' property for remove button and when hovering in text area. 
- Updated button name from edit to set. 
- Updated goal input field placeholder text.

On homepage:
- Removed info block's backgrounds.
- Sped up info block's animation speed. 
- Reduced top margin on top info block. 
- Reduced bottom margin for bottom info block. 

Suggestions:
Currently hitting set button only 'sets' the text. Recommend adjusting form so that the button only appears when 'touched' (formik property) or focused (css property). Otherwise only remove goal button visible as well as the future 'complete' button. 